### PR TITLE
no prefix for the bot

### DIFF
--- a/TGS.Server/Instance/Interop.cs
+++ b/TGS.Server/Instance/Interop.cs
@@ -109,7 +109,7 @@ namespace TGS.Server
 			switch (cmd)
 			{
 				case SRIRCBroadcast:
-					SendMessage("GAME: " + String.Join(" ", splits), MessageType.GameInfo);
+					SendMessage(String.Join(" ", splits), MessageType.GameInfo);
 					break;
 				case SRKillProcessSilent:
 					showKillMessage = false;


### PR DESCRIPTION
:cl:
Removes the GAME: prefix from the bot game broadcast messages, for tgmc snowflake
/:cl:

